### PR TITLE
Fix create referral when org is already in the db

### DIFF
--- a/src/FamilyHubs.Referral.Core/Commands/CreateReferral/CreateReferralCommand.cs
+++ b/src/FamilyHubs.Referral.Core/Commands/CreateReferral/CreateReferralCommand.cs
@@ -137,6 +137,7 @@ public class CreateReferralCommandHandler : IRequestHandler<CreateReferralComman
         }
         return entity;
     }
+
     private async Task<Data.Entities.Referral> AttachExistingService(Data.Entities.Referral entity)
     {
         Data.Entities.ReferralService? referralService = _context.ReferralServices.SingleOrDefault(x => x.Id == entity.ReferralService.Id);
@@ -179,4 +180,50 @@ public class CreateReferralCommandHandler : IRequestHandler<CreateReferralComman
         }
         return entity;
     }
+
+    //private async Task<Data.Entities.Referral> AttachExistingService(Data.Entities.Referral entity)
+    //{
+    //    Data.Entities.ReferralService? referralService = _context.ReferralServices.SingleOrDefault(x => x.Id == entity.ReferralService.Id);
+    //    if (referralService == null)
+    //    {
+    //        ServiceDirectory.Shared.Dto.ServiceDto? sdService = await _serviceDirectoryService.GetServiceById(entity.ReferralService.Id);
+    //        if (sdService == null)
+    //        {
+    //            throw new ArgumentException($"Failed to return Service from service directory for Id = {entity.ReferralService.Id}");
+    //        }
+
+    //        ServiceDirectory.Shared.Dto.OrganisationDto? sdOrganisation = await _serviceDirectoryService.GetOrganisationById(sdService.OrganisationId);
+    //        if (sdOrganisation == null)
+    //        {
+    //            throw new ArgumentException($"Failed to return Organisation from service directory for Id = {sdService.OrganisationId}");
+    //        }
+
+    //        // check if the organization already exists
+    //        Organisation existingOrganisation = await _context.Organisations.FindAsync(sdOrganisation.Id)
+    //                                            ?? new Organisation
+    //        {
+    //            Id = sdOrganisation.Id,
+    //            Name = sdOrganisation.Name,
+    //            Description = sdOrganisation.Description,
+    //        };
+
+    //        Data.Entities.ReferralService srv = new Data.Entities.ReferralService
+    //        {
+    //            Id = sdService.Id,
+    //            Name = sdService.Name,
+    //            Description = sdService.Description,
+    //            Organisation = existingOrganisation,
+    //        };
+
+    //        _context.ReferralServices.Add(srv);
+    //        await _context.SaveChangesAsync();
+    //        referralService = _context.ReferralServices.SingleOrDefault(x => x.Id == entity.ReferralService.Id);
+    //    }
+
+    //    if (referralService != null)
+    //    {
+    //        entity.ReferralService = referralService;
+    //    }
+    //    return entity;
+    //}
 }

--- a/src/FamilyHubs.Referral.Core/Commands/CreateReferral/CreateReferralCommand.cs
+++ b/src/FamilyHubs.Referral.Core/Commands/CreateReferral/CreateReferralCommand.cs
@@ -155,18 +155,21 @@ public class CreateReferralCommandHandler : IRequestHandler<CreateReferralComman
                 throw new ArgumentException($"Failed to return Organisation from service directory for Id = {sdService.OrganisationId}");
             }
 
+            // check if the organization already exists
+            Organisation existingOrganisation = await _context.Organisations.FindAsync(sdOrganisation.Id)
+                                                ?? new Organisation
+                                                {
+                                                    Id = sdOrganisation.Id,
+                                                    Name = sdOrganisation.Name,
+                                                    Description = sdOrganisation.Description,
+                                                };
+
             Data.Entities.ReferralService srv = new Data.Entities.ReferralService
             {
                 Id = sdService.Id,
                 Name = sdService.Name,
                 Description = sdService.Description,
-                Organisation = new Organisation
-                {
-                    Id = sdOrganisation.Id,
-                    ReferralServiceId = sdService.Id,
-                    Name = sdOrganisation.Name,
-                    Description = sdOrganisation.Description,
-                }
+                Organisation = existingOrganisation,
             };
 
             _context.ReferralServices.Add(srv);
@@ -180,50 +183,4 @@ public class CreateReferralCommandHandler : IRequestHandler<CreateReferralComman
         }
         return entity;
     }
-
-    //private async Task<Data.Entities.Referral> AttachExistingService(Data.Entities.Referral entity)
-    //{
-    //    Data.Entities.ReferralService? referralService = _context.ReferralServices.SingleOrDefault(x => x.Id == entity.ReferralService.Id);
-    //    if (referralService == null)
-    //    {
-    //        ServiceDirectory.Shared.Dto.ServiceDto? sdService = await _serviceDirectoryService.GetServiceById(entity.ReferralService.Id);
-    //        if (sdService == null)
-    //        {
-    //            throw new ArgumentException($"Failed to return Service from service directory for Id = {entity.ReferralService.Id}");
-    //        }
-
-    //        ServiceDirectory.Shared.Dto.OrganisationDto? sdOrganisation = await _serviceDirectoryService.GetOrganisationById(sdService.OrganisationId);
-    //        if (sdOrganisation == null)
-    //        {
-    //            throw new ArgumentException($"Failed to return Organisation from service directory for Id = {sdService.OrganisationId}");
-    //        }
-
-    //        // check if the organization already exists
-    //        Organisation existingOrganisation = await _context.Organisations.FindAsync(sdOrganisation.Id)
-    //                                            ?? new Organisation
-    //        {
-    //            Id = sdOrganisation.Id,
-    //            Name = sdOrganisation.Name,
-    //            Description = sdOrganisation.Description,
-    //        };
-
-    //        Data.Entities.ReferralService srv = new Data.Entities.ReferralService
-    //        {
-    //            Id = sdService.Id,
-    //            Name = sdService.Name,
-    //            Description = sdService.Description,
-    //            Organisation = existingOrganisation,
-    //        };
-
-    //        _context.ReferralServices.Add(srv);
-    //        await _context.SaveChangesAsync();
-    //        referralService = _context.ReferralServices.SingleOrDefault(x => x.Id == entity.ReferralService.Id);
-    //    }
-
-    //    if (referralService != null)
-    //    {
-    //        entity.ReferralService = referralService;
-    //    }
-    //    return entity;
-    //}
 }

--- a/src/FamilyHubs.Referral.Core/Commands/CreateReferral/CreateReferralCommand.cs
+++ b/src/FamilyHubs.Referral.Core/Commands/CreateReferral/CreateReferralCommand.cs
@@ -149,27 +149,30 @@ public class CreateReferralCommandHandler : IRequestHandler<CreateReferralComman
                 throw new ArgumentException($"Failed to return Service from service directory for Id = {entity.ReferralService.Id}");
             }
 
-            ServiceDirectory.Shared.Dto.OrganisationDto? sdOrganisation = await _serviceDirectoryService.GetOrganisationById(sdService.OrganisationId);
-            if (sdOrganisation == null)
-            {
-                throw new ArgumentException($"Failed to return Organisation from service directory for Id = {sdService.OrganisationId}");
-            }
-
             // check if the organization already exists
-            Organisation existingOrganisation = await _context.Organisations.FindAsync(sdOrganisation.Id)
-                                                ?? new Organisation
-                                                {
-                                                    Id = sdOrganisation.Id,
-                                                    Name = sdOrganisation.Name,
-                                                    Description = sdOrganisation.Description,
-                                                };
+            Organisation? organisation = await _context.Organisations.FindAsync(sdService.OrganisationId);
+            if (organisation == null)
+            {
+                ServiceDirectory.Shared.Dto.OrganisationDto? sdOrganisation = await _serviceDirectoryService.GetOrganisationById(sdService.OrganisationId);
+                if (sdOrganisation == null)
+                {
+                    throw new ArgumentException($"Failed to return Organisation from service directory for Id = {sdService.OrganisationId}");
+                }
+
+                organisation = new Organisation
+                {
+                    Id = sdOrganisation.Id,
+                    Name = sdOrganisation.Name,
+                    Description = sdOrganisation.Description,
+                };
+            }
 
             Data.Entities.ReferralService srv = new Data.Entities.ReferralService
             {
                 Id = sdService.Id,
                 Name = sdService.Name,
                 Description = sdService.Description,
-                Organisation = existingOrganisation,
+                Organisation = organisation
             };
 
             _context.ReferralServices.Add(srv);

--- a/src/FamilyHubs.Referral.Core/Commands/CreateReferral/CreateReferralCommand.cs
+++ b/src/FamilyHubs.Referral.Core/Commands/CreateReferral/CreateReferralCommand.cs
@@ -150,6 +150,7 @@ public class CreateReferralCommandHandler : IRequestHandler<CreateReferralComman
             }
 
             // check if the organization already exists
+            //todo: do we need to update the organisation from the sd, if it already exists?
             Organisation? organisation = await _context.Organisations.FindAsync(sdService.OrganisationId);
             if (organisation == null)
             {

--- a/src/FamilyHubs.Referral.Core/Commands/CreateReferral/CreateReferralCommand.cs
+++ b/src/FamilyHubs.Referral.Core/Commands/CreateReferral/CreateReferralCommand.cs
@@ -160,11 +160,12 @@ public class CreateReferralCommandHandler : IRequestHandler<CreateReferralComman
                     throw new ArgumentException($"Failed to return Organisation from service directory for Id = {sdService.OrganisationId}");
                 }
 
+                //todo: Organisation has a ReferralServiceId, but an organisation can have multiple services
                 organisation = new Organisation
                 {
                     Id = sdOrganisation.Id,
                     Name = sdOrganisation.Name,
-                    Description = sdOrganisation.Description,
+                    Description = sdOrganisation.Description
                 };
             }
 


### PR DESCRIPTION
Fix an 'organisation already exists' issue when a referral is created and the service is new to the referral DB, but the organisation is already in the referral DB because a referral was already created for one of the organisation's other services.

Note that in the DB schema, the Organisation has a reference to a single Service, but an Organisation can have many services. Fortunately no consumers seem to rely on the Organisation's service, but we should look to either remove it, or reverse the one to many relationship if it will be required later.

We also probably need to update the organisation in the referral DB from the service directory, if it's already in the referral DB.